### PR TITLE
Fix HTTP stream calls and tests

### DIFF
--- a/Iggy_SDK/Contracts/Http/StreamResponse.cs
+++ b/Iggy_SDK/Contracts/Http/StreamResponse.cs
@@ -3,11 +3,9 @@ namespace Iggy_SDK.Contracts.Http;
 
 public sealed class StreamResponse
 {
-    //{"id":940,"created_at":1725877995143672,"name":"test-stream33seze1n76bbpq","size":"0 B","messages_count":0,"topics_count":0,"topics":[]}
-    
     public required int Id { get; init; }
     public required string Name { get; init; }
-    public required ulong Size { get; init; }//
+    public required ulong Size { get; init; }
     public required DateTimeOffset CreatedAt { get; init; }
     public required ulong MessagesCount { get; init; }
     public required int TopicsCount { get; init; }

--- a/Iggy_SDK/Contracts/Http/StreamResponse.cs
+++ b/Iggy_SDK/Contracts/Http/StreamResponse.cs
@@ -3,9 +3,11 @@ namespace Iggy_SDK.Contracts.Http;
 
 public sealed class StreamResponse
 {
+    //{"id":940,"created_at":1725877995143672,"name":"test-stream33seze1n76bbpq","size":"0 B","messages_count":0,"topics_count":0,"topics":[]}
+    
     public required int Id { get; init; }
     public required string Name { get; init; }
-    public required ulong SizeBytes { get; init; }
+    public required ulong Size { get; init; }//
     public required DateTimeOffset CreatedAt { get; init; }
     public required ulong MessagesCount { get; init; }
     public required int TopicsCount { get; init; }

--- a/Iggy_SDK/IggyClient/Implementations/HttpMessageStream.cs
+++ b/Iggy_SDK/IggyClient/Implementations/HttpMessageStream.cs
@@ -64,11 +64,14 @@ public class HttpMessageStream : IIggyClient
     public async Task<StreamResponse?> GetStreamByIdAsync(Identifier streamId, CancellationToken token = default)
     {
         var response = await _httpClient.GetAsync($"/streams/{streamId}", token);
+        
         if (response.IsSuccessStatusCode)
         {
             return await response.Content.ReadFromJsonAsync<StreamResponse>(JsonConverterFactory.StreamResponseOptions, cancellationToken: token);
         }
+        
         await HandleResponseAsync(response);
+        
         return null;
     }
 

--- a/Iggy_SDK/JsonConfiguration/StreamResponseConverter.cs
+++ b/Iggy_SDK/JsonConfiguration/StreamResponseConverter.cs
@@ -15,7 +15,7 @@ public sealed class StreamResponseConverter : JsonConverter<StreamResponse>
         var id = root.GetProperty(nameof(StreamResponse.Id).ToSnakeCase()).GetInt32();
         var createdAt = root.GetProperty(nameof(StreamResponse.CreatedAt).ToSnakeCase()).GetUInt64();
         var name = root.GetProperty(nameof(StreamResponse.Name).ToSnakeCase()).GetString();
-        var sizeBytesString = root.GetProperty(nameof(StreamResponse.SizeBytes).ToSnakeCase()).GetString();
+        var sizeBytesString = root.GetProperty(nameof(StreamResponse.Size).ToSnakeCase()).GetString();
         var sizeBytesStringSplit = sizeBytesString.Split(' ');
         var (sizeBytesVal, Unit) = (ulong.Parse(sizeBytesStringSplit[0]), sizeBytesStringSplit[1]);
         var sizeBytes = Unit switch
@@ -42,7 +42,7 @@ public sealed class StreamResponseConverter : JsonConverter<StreamResponse>
         {
             Id = id,
             Name = name!,
-            SizeBytes = sizeBytes,
+            Size = sizeBytes,
             CreatedAt = DateTimeOffsetUtils.FromUnixTimeMicroSeconds(createdAt).LocalDateTime,
             MessagesCount = messagesCount,
             TopicsCount = topicsCount,

--- a/Iggy_SDK/Mappers/BinaryMapper.cs
+++ b/Iggy_SDK/Mappers/BinaryMapper.cs
@@ -556,7 +556,7 @@ internal static class BinaryMapper
             Topics = topics,
             CreatedAt = stream.CreatedAt,
             MessagesCount = stream.MessagesCount,
-            SizeBytes = stream.SizeBytes
+            Size = stream.Size
         };
     }
 
@@ -578,7 +578,7 @@ internal static class BinaryMapper
                 Id = id,
                 TopicsCount = topicsCount,
                 Name = name,
-                SizeBytes = sizeBytes,
+                Size = sizeBytes,
                 MessagesCount = messagesCount,
                 CreatedAt = DateTimeOffsetUtils.FromUnixTimeMicroSeconds(createdAt).LocalDateTime
             }, readBytes);

--- a/Iggy_SDK_Tests/E2ETests/StreamsE2E.cs
+++ b/Iggy_SDK_Tests/E2ETests/StreamsE2E.cs
@@ -144,8 +144,7 @@ public sealed class StreamsE2E : IClassFixture<IggyStreamFixture>
         // })).ToArray();
         // await Task.WhenAll(tasks);
     }
-
-    // [Fact(Skip = SkipMessage), TestPriority(7)]
+    
     [Fact, TestPriority(7)]
     public async Task GetStreamById_Should_Throw_InvalidResponse()
     {

--- a/Iggy_SDK_Tests/E2ETests/StreamsE2E.cs
+++ b/Iggy_SDK_Tests/E2ETests/StreamsE2E.cs
@@ -17,93 +17,152 @@ public sealed class StreamsE2E : IClassFixture<IggyStreamFixture>
     {
         _fixture = fixture;
     }
-
-    [Fact(Skip = SkipMessage), TestPriority(1)]
+    
+    [Fact, TestPriority(1)]
     public async Task CreateStream_HappyPath_Should_CreateStream_Successfully()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x => await x.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
-                .Should()
-                .NotThrowAsync();
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act & assert
+        await _fixture.HttpSut.Invoking(y => y.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
+            .Should()
+            .NotThrowAsync();
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x => await x.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
+        //         .Should()
+        //         .NotThrowAsync();
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
     }
-
-    [Fact(Skip = SkipMessage), TestPriority(2)]
+    
+    [Fact, TestPriority(2)]
     public async Task CreateStream_Duplicate_Should_Throw_InvalidResponse()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x => await x.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
-                .Should()
-                .ThrowExactlyAsync<InvalidResponseException>();
-        })).ToArray();
-        await Task.WhenAll(tasks);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(3)]
-    public async Task GetStreamById_Should_ReturnValidResponse()
-    {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            var response = await sut.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
-            response.Should().NotBeNull();
-            response!.Id.Should().Be(StreamsFixtureBootstrap.StreamRequest.StreamId);
-            response.Name.Should().Be(StreamsFixtureBootstrap.StreamRequest.Name);
-        })).ToArray();
-        await Task.WhenAll(tasks);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(4)]
-    public async Task UpdateStream_Should_UpdateStream_Successfully()
-    {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x => await x.UpdateStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!), StreamsFixtureBootstrap.UpdateStreamRequest))
-                .Should()
-                .NotThrowAsync();
-            var result = await sut.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
-            result.Should().NotBeNull();
-            result!.Name.Should().Be(StreamsFixtureBootstrap.UpdateStreamRequest.Name);
-        })).ToArray();
-        await Task.WhenAll(tasks);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(5)]
-    public async Task DeleteStream_Should_DeleteStream_Successfully()
-    {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x => await x.DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
-                .Should()
-                .NotThrowAsync();
-        })).ToArray();
-        await Task.WhenAll(tasks);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(6)]
-    public async Task DeleteStream_Should_Throw_InvalidResponse()
-    {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x => await x.DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
-                .Should()
-                .ThrowExactlyAsync<InvalidResponseException>();
-        })).ToArray();
-        await Task.WhenAll(tasks);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(7)]
-    public async Task GetStreamById_Should_Throw_InvalidResponse()
-    {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(async x =>
-                await x.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
+        // act & assert
+        await _fixture.HttpSut.Invoking(y => y.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
             .Should()
             .ThrowExactlyAsync<InvalidResponseException>();
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x => await x.CreateStreamAsync(StreamsFixtureBootstrap.StreamRequest))
+        //         .Should()
+        //         .ThrowExactlyAsync<InvalidResponseException>();
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
+    }
+    
+    [Fact, TestPriority(3)]
+    public async Task GetStreamById_Should_ReturnValidResponse()
+    {
+        // act
+        var response = await _fixture.HttpSut.GetStreamByIdAsync(
+            Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
+        
+        // assert
+        response.Should().NotBeNull();
+        response!.Id.Should().Be(StreamsFixtureBootstrap.StreamRequest.StreamId);
+        response.Name.Should().Be(StreamsFixtureBootstrap.StreamRequest.Name);
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     var response = await sut.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
+        //     response.Should().NotBeNull();
+        //     response!.Id.Should().Be(StreamsFixtureBootstrap.StreamRequest.StreamId);
+        //     response.Name.Should().Be(StreamsFixtureBootstrap.StreamRequest.Name);
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
+    }
+    
+    [Fact, TestPriority(4)]
+    public async Task UpdateStream_Should_UpdateStream_Successfully()
+    {
+        // act
+        await _fixture.HttpSut.Invoking(y => y.UpdateStreamAsync(
+                Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!),
+                StreamsFixtureBootstrap.UpdateStreamRequest))
+            .Should()
+            .NotThrowAsync();
+        
+        var result = await _fixture.HttpSut.GetStreamByIdAsync(
+            Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
+        
+        // assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be(StreamsFixtureBootstrap.UpdateStreamRequest.Name);
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x => await x.UpdateStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!), StreamsFixtureBootstrap.UpdateStreamRequest))
+        //         .Should()
+        //         .NotThrowAsync();
+        //     var result = await sut.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!));
+        //     result.Should().NotBeNull();
+        //     result!.Name.Should().Be(StreamsFixtureBootstrap.UpdateStreamRequest.Name);
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
+    }
+
+    [Fact, TestPriority(5)]
+    public async Task DeleteStream_Should_DeleteStream_Successfully()
+    {
+        // act
+        await _fixture.HttpSut.Invoking(y => y
+                .DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!))
+            ).Should()
+            .NotThrowAsync();
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x => await x.DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
+        //         .Should()
+        //         .NotThrowAsync();
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
+    }
+    
+    [Fact, TestPriority(6)]
+    public async Task DeleteStream_Should_Throw_InvalidResponse()
+    {
+        // act
+        await _fixture.HttpSut.Invoking(y => y
+                .DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!))
+            ).Should()
+            .ThrowExactlyAsync<InvalidResponseException>();
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x => await x.DeleteStreamAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
+        //         .Should()
+        //         .ThrowExactlyAsync<InvalidResponseException>();
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
+    }
+
+    // [Fact(Skip = SkipMessage), TestPriority(7)]
+    [Fact, TestPriority(7)]
+    public async Task GetStreamById_Should_Throw_InvalidResponse()
+    {
+        // act
+        await _fixture.HttpSut.Invoking(y => y
+                .GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!))
+            ).Should()
+            .ThrowExactlyAsync<InvalidResponseException>();
+        
+        // TODO: This code block is commmented bacause TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(async x =>
+        //         await x.GetStreamByIdAsync(Identifier.Numeric((int)StreamsFixtureBootstrap.StreamRequest.StreamId!)))
+        //     .Should()
+        //     .ThrowExactlyAsync<InvalidResponseException>();
+        // })).ToArray();
+        // await Task.WhenAll(tasks);
     }
 }

--- a/Iggy_SDK_Tests/MapperTests/BinaryMapper.cs
+++ b/Iggy_SDK_Tests/MapperTests/BinaryMapper.cs
@@ -166,14 +166,14 @@ public sealed class BinaryMapper
         var response1 = responses.ElementAt(0);
         Assert.Equal(id1, response1.Id);
         Assert.Equal(topicsCount1, response1.TopicsCount);
-        Assert.Equal(sizeBytes, response1.SizeBytes);
+        Assert.Equal(sizeBytes, response1.Size);
         Assert.Equal(messagesCount, response1.MessagesCount);
         Assert.Equal(name1, response1.Name);
 
         var response2 = responses.ElementAt(1);
         Assert.Equal(id2, response2.Id);
         Assert.Equal(topicsCount2, response2.TopicsCount);
-        Assert.Equal(sizeBytes2, response2.SizeBytes);
+        Assert.Equal(sizeBytes2, response2.Size);
         Assert.Equal(messagesCount2, response2.MessagesCount);
         Assert.Equal(name2, response2.Name);
     }
@@ -208,7 +208,7 @@ public sealed class BinaryMapper
         Assert.Equal(id, response.Id);
         Assert.Equal(topicsCount, response.TopicsCount);
         Assert.Equal(name, response.Name);
-        Assert.Equal(sizeBytes, response.SizeBytes);
+        Assert.Equal(sizeBytes, response.Size);
         Assert.Equal(messagesCount, response.MessagesCount);
         Assert.NotNull(response.Topics);
         Assert.Single(response.Topics.ToList());

--- a/Iggy_SDK_Tests/Utils/Streams/StreamFactory.cs
+++ b/Iggy_SDK_Tests/Utils/Streams/StreamFactory.cs
@@ -33,7 +33,7 @@ internal static class StreamFactory
         return new StreamResponse
         {
             Id = Random.Shared.Next(1, 10),
-            SizeBytes = (ulong)Random.Shared.Next(1, 10),
+            Size = (ulong)Random.Shared.Next(1, 10),
             MessagesCount = (ulong)Random.Shared.Next(1, 10),
             CreatedAt = DateTimeOffset.UtcNow,
             Name = "Test Topic" + Random.Shared.Next(1, 69),


### PR DESCRIPTION
Regarding the small changes in the HTTP Stream response, were made the following fixes:
- Fix E2E tests, considering only test HTTP protocol method implementation
- Fix the StreamResponse class to represent the new stream response payload.