### PR TITLE
Fix HTTP ConsumerGroup tests & Utils tests

### DIFF
--- a/Iggy_SDK/JsonConfiguration/StatsResponseConverter.cs
+++ b/Iggy_SDK/JsonConfiguration/StatsResponseConverter.cs
@@ -12,96 +12,40 @@ public class StatsResponseConverter : JsonConverter<StatsResponse>
     {
         using var doc = JsonDocument.ParseValue(ref reader);
         var root = doc.RootElement;
-
-        //int processId = root.GetProperty(nameof(Stats.ProcessId).ToSnakeCase()).GetInt32();
+        
         int processId = root.GetProperty(nameof(Stats.ProcessId).ToSnakeCase()).GetInt32();
         float cpuUsage = root.GetProperty(nameof(Stats.CpuUsage).ToSnakeCase()).GetSingle();
         float totalCpuUsage = root.GetProperty(nameof(Stats.TotalCpuUsage).ToSnakeCase()).GetSingle();
+        
         string? memoryUsageString = root.GetProperty(nameof(Stats.MemoryUsage).ToSnakeCase()).GetString();
         string[] memoryUsageStringSplit = memoryUsageString.Split(' ');
         (ulong memoryUsageBytesVal, string memoryUnit) = (ulong.Parse(memoryUsageStringSplit[0]), memoryUsageStringSplit[1]);
-        ulong memoryUsage = memoryUnit switch
-        {
-            "B" => memoryUsageBytesVal,
-            "KiB" => memoryUsageBytesVal * (ulong)1e03,
-            "MiB" => memoryUsageBytesVal * (ulong)1e06,
-            "GiB" => memoryUsageBytesVal * (ulong)1e09,
-            "TiB" => memoryUsageBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing MemoryUsage")
-        };
+        ulong memoryUsage = ConvertStringBytesToUlong(memoryUnit, memoryUsageBytesVal);
+        
         string? totalMemoryString = root.GetProperty(nameof(Stats.TotalMemory).ToSnakeCase()).GetString();
         string[] totalMemoryStringSplit = totalMemoryString.Split(' ');
         (ulong totalMemoryUsageBytesVal, string totalMemoryUnit) = (ulong.Parse(totalMemoryStringSplit[0]), totalMemoryStringSplit[1]);
-        ulong totalMemoryUsage = totalMemoryUnit switch
-        {
-            "B" => totalMemoryUsageBytesVal,
-            "KiB" => totalMemoryUsageBytesVal * (ulong)1e03,
-            "MiB" => totalMemoryUsageBytesVal * (ulong)1e06,
-            "GiB" => totalMemoryUsageBytesVal * (ulong)1e09,
-            "TiB" => totalMemoryUsageBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing TotalMemoryUsage")
-        };
+        ulong totalMemoryUsage = ConvertStringBytesToUlong(totalMemoryUnit, totalMemoryUsageBytesVal);
+        
         string? availableMemoryString = root.GetProperty(nameof(Stats.AvailableMemory).ToSnakeCase()).GetString();
         string[] availableMemoryStringSplit = availableMemoryString.Split(' ');
         (ulong availableMemoryBytesVal, string availableMemoryUnit) = (ulong.Parse(availableMemoryStringSplit[0]), availableMemoryStringSplit[1]);
-        ulong availableMemory = availableMemoryUnit switch
-        {
-            "B" => availableMemoryBytesVal,
-            "KiB" => availableMemoryBytesVal * (ulong)1e03,
-            "MiB" => availableMemoryBytesVal * (ulong)1e06,
-            "GiB" => availableMemoryBytesVal * (ulong)1e09,
-            "TiB" => availableMemoryBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing AvailableMemory")
-        };
-        var runtimeRoot = root.GetProperty(nameof(Stats.RunTime).ToSnakeCase());
-        ulong runtimeNanos = 0;
-        foreach (var runtimeProp in runtimeRoot.EnumerateObject())
-        {
-            var durationProp = runtimeProp.Value;
-            var props = durationProp.EnumerateObject();
-            ulong secsValue = props.First().Value.GetUInt64();
-            ulong nanosValue = props.Last().Value.GetUInt64();
-            nanosValue += secsValue * (ulong)1e09;
-            runtimeNanos = nanosValue;
-        }
-
+        ulong availableMemory = ConvertStringBytesToUlong(availableMemoryUnit, availableMemoryBytesVal);
+        
+        var runtime = root.GetProperty(nameof(Stats.RunTime).ToSnakeCase()).GetUInt64();
         ulong startTime = root.GetProperty(nameof(Stats.StartTime).ToSnakeCase()).GetUInt64();
         string? readBytesString = root.GetProperty(nameof(Stats.ReadBytes).ToSnakeCase()).GetString();
         string[] readBytesStringSplit = readBytesString.Split(' ');
         (ulong readBytesVal, string readBytesUnit) = (ulong.Parse(readBytesStringSplit[0]), readBytesStringSplit[1]);
-        ulong readBytes = readBytesUnit switch
-        {
-            "B" => readBytesVal,
-            "KB" => readBytesVal * (ulong)1e03,
-            "MB" => readBytesVal * (ulong)1e06,
-            "GB" => readBytesVal * (ulong)1e09,
-            "TB" => readBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing ReadBytes")
-        };
+        ulong readBytes = ConvertStringBytesToUlong(readBytesUnit, readBytesVal);
         string? writtenBytesString = root.GetProperty(nameof(Stats.WrittenBytes).ToSnakeCase()).GetString();
         string[] writtenBytesStringSplit = writtenBytesString.Split(' ');
         (ulong writtenBytesVal, string writtenBytesUnit) = (ulong.Parse(writtenBytesStringSplit[0]), writtenBytesStringSplit[1]);
-        ulong writtenBytes = writtenBytesUnit switch
-        {
-            "B" => writtenBytesVal,
-            "KiB" => writtenBytesVal * (ulong)1e03,
-            "MiB" => writtenBytesVal * (ulong)1e06,
-            "GiB" => writtenBytesVal * (ulong)1e09,
-            "TiB" => writtenBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing WrittenBytes")
-        };
+        ulong writtenBytes = ConvertStringBytesToUlong(writtenBytesUnit, writtenBytesVal);
         string? messageWrittenSizeBytesString = root.GetProperty(nameof(Stats.MessagesSizeBytes).ToSnakeCase()).GetString();
         string[] messageWrittenSizeBytesStringSplit = messageWrittenSizeBytesString.Split(' ');
         (ulong messageWrittenSizeBytesVal, string messageWrittenSizeBytesUnit) = (ulong.Parse(messageWrittenSizeBytesStringSplit[0]), messageWrittenSizeBytesStringSplit[1]);
-        ulong messageWrittenSizeBytes = messageWrittenSizeBytesUnit switch
-        {
-            "B" => messageWrittenSizeBytesVal,
-            "KB" => messageWrittenSizeBytesVal * (ulong)1e03,
-            "MB" => messageWrittenSizeBytesVal * (ulong)1e06,
-            "GB" => messageWrittenSizeBytesVal * (ulong)1e09,
-            "TB" => messageWrittenSizeBytesVal * (ulong)1e12,
-            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing MessageWrittenBytes")
-        };
+        ulong messageWrittenSizeBytes = ConvertStringBytesToUlong(messageWrittenSizeBytesUnit, messageWrittenSizeBytesVal);
         int streamsCount = root.GetProperty(nameof(Stats.StreamsCount).ToSnakeCase()).GetInt32();
         int topicsCount = root.GetProperty(nameof(Stats.TopicsCount).ToSnakeCase()).GetInt32();
         int partitionsCount = root.GetProperty(nameof(Stats.PartitionsCount).ToSnakeCase()).GetInt32();
@@ -130,7 +74,7 @@ public class StatsResponseConverter : JsonConverter<StatsResponse>
             PartitionsCount = partitionsCount,
             ProcessId = processId,
             ReadBytes = readBytes,
-            RunTime = runtimeNanos,
+            RunTime = runtime,
             SegmentsCount = segmentsCount,
             StartTime = startTime,
             StreamsCount = streamsCount,
@@ -140,6 +84,20 @@ public class StatsResponseConverter : JsonConverter<StatsResponse>
             WrittenBytes = writtenBytes
         };
 
+    }
+
+    private static ulong ConvertStringBytesToUlong(string memoryUnit, ulong memoryUsageBytesVal)
+    {
+        ulong memoryUsage = memoryUnit switch
+        {
+            "B" => memoryUsageBytesVal,
+            "KiB" => memoryUsageBytesVal * (ulong)1e03,
+            "MiB" => memoryUsageBytesVal * (ulong)1e06,
+            "GiB" => memoryUsageBytesVal * (ulong)1e09,
+            "TiB" => memoryUsageBytesVal * (ulong)1e12,
+            _ => throw new InvalidEnumArgumentException("Error Wrong Unit when deserializing MemoryUsage")
+        };
+        return memoryUsage;
     }
 
     public override void Write(Utf8JsonWriter writer, StatsResponse value, JsonSerializerOptions options)

--- a/Iggy_SDK_Tests/E2ETests/ConsumerGroupE2E.cs
+++ b/Iggy_SDK_Tests/E2ETests/ConsumerGroupE2E.cs
@@ -13,20 +13,31 @@ namespace Iggy_SDK_Tests.E2ETests;
 public sealed class ConsumerGroupE2E : IClassFixture<IggyConsumerGroupFixture>
 {
     private const string SkipMessage = "TCP implementation needs to be aligned with Iggyrs core changes";
+    
     private readonly IggyConsumerGroupFixture _fixture;
 
-    private static readonly CreateConsumerGroupRequest _createConsumerGroupRequest = ConsumerGroupFactory.CreateRequest((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!,
-        (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!, GROUP_ID);
-
-    private static readonly JoinConsumerGroupRequest _joinConsumerGroupRequest = ConsumerGroupFactory.CreateJoinGroupRequest((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
-        (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
-
-    private static readonly LeaveConsumerGroupRequest _leaveConsumerGroupRequest = ConsumerGroupFactory.CreateLeaveGroupRequest((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
-        (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
-
-    private static readonly DeleteConsumerGroupRequest _deleteConsumerGroupRequest = ConsumerGroupFactory.CreateDeleteGroupRequest((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
-        (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
     private const int GROUP_ID = 1;
+    
+    private static readonly CreateConsumerGroupRequest _createConsumerGroupRequest =
+        ConsumerGroupFactory.CreateRequest(
+            (int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!,
+            (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!, GROUP_ID);
+
+    private static readonly JoinConsumerGroupRequest _joinConsumerGroupRequest =
+        ConsumerGroupFactory.CreateJoinGroupRequest(
+            (int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
+            (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
+
+    private static readonly LeaveConsumerGroupRequest _leaveConsumerGroupRequest =
+        ConsumerGroupFactory.CreateLeaveGroupRequest(
+            (int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
+            (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
+
+    private static readonly DeleteConsumerGroupRequest _deleteConsumerGroupRequest =
+        ConsumerGroupFactory.CreateDeleteGroupRequest(
+            (int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId,
+            (int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId, GROUP_ID);
+    
     private Identifier ConsumerGroupId = Identifier.Numeric(GROUP_ID);
 
     public ConsumerGroupE2E(IggyConsumerGroupFixture fixture)
@@ -34,74 +45,113 @@ public sealed class ConsumerGroupE2E : IClassFixture<IggyConsumerGroupFixture>
         _fixture = fixture;
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(1)]
+    [Fact, TestPriority(1)]
     public async Task CreateConsumerGroup_HappyPath_Should_CreateConsumerGroup_Successfully()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.CreateConsumerGroupAsync(_createConsumerGroupRequest);
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act & assert
+        await _fixture.HttpSut.Invoking(y =>
+                y.CreateConsumerGroupAsync(_createConsumerGroupRequest)
+            ).Should()
+            .NotThrowAsync();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.CreateConsumerGroupAsync(_createConsumerGroupRequest);
+        // })).ToArray();
+        //
+        // await Task.WhenAll(tasks);
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(2)]
+    [Fact, TestPriority(2)]
     public async Task CreateConsumerGroup_Should_Throw_InvalidResponse()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(x => x.CreateConsumerGroupAsync(_createConsumerGroupRequest))
-                .Should()
-                .ThrowExactlyAsync<InvalidResponseException>();
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act & assert
+        await _fixture.HttpSut.Invoking(y =>
+                y.CreateConsumerGroupAsync(_createConsumerGroupRequest)
+            ).Should()
+            .ThrowExactlyAsync<InvalidResponseException>();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(x => x.CreateConsumerGroupAsync(_createConsumerGroupRequest))
+        //         .Should()
+        //         .ThrowExactlyAsync<InvalidResponseException>();
+        // })).ToArray();
+        //
+        // await Task.WhenAll(tasks);
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(3)]
+    [Fact, TestPriority(3)]
     public async Task GetConsumerGroupById_Should_Return_ValidResponse()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            var response = await sut.GetConsumerGroupByIdAsync(
-                Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!), Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!),
-                ConsumerGroupId);
-
-            response.Should().NotBeNull();
-            response!.Id.Should().Be(GROUP_ID);
-            response.PartitionsCount.Should().Be(ConsumerGroupFixtureBootstrap.TopicRequest.PartitionsCount);
-            response.MembersCount.Should().Be(0);
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act
+        var response = await _fixture.HttpSut
+                .GetConsumerGroupByIdAsync(
+                    Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!),
+                    Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!),
+                    ConsumerGroupId);
+        
+        // assert
+        response.Should().NotBeNull();
+        
+        response!.Id.Should().Be(GROUP_ID);
+        
+        response.PartitionsCount
+            .Should()
+            .Be(ConsumerGroupFixtureBootstrap.TopicRequest.PartitionsCount);
+        
+        response.MembersCount.Should().Be(0);
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     var response = await sut.GetConsumerGroupByIdAsync(
+        //         Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!), Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!),
+        //         ConsumerGroupId);
+        //
+        //     response.Should().NotBeNull();
+        //     response!.Id.Should().Be(GROUP_ID);
+        //     response.PartitionsCount.Should().Be(ConsumerGroupFixtureBootstrap.TopicRequest.PartitionsCount);
+        //     response.MembersCount.Should().Be(0);
+        // })).ToArray();
+        //
+        // await Task.WhenAll(tasks);
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(4)]
+    [Fact, TestPriority(4)]
     public async Task JoinConsumerGroup_Should_JoinConsumerGroup_Successfully()
     {
-        var sut = _fixture.SubjectsUnderTest[0];
-        await sut.Invoking(x => x.JoinConsumerGroupAsync(_joinConsumerGroupRequest))
-            .Should()
-            .NotThrowAsync();
+        // act & assert
+        await _fixture.HttpSut.Invoking(y =>
+                y.JoinConsumerGroupAsync(_joinConsumerGroupRequest)
+            ).Should()
+            .ThrowExactlyAsync<FeatureUnavailableException>();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var sut = _fixture.SubjectsUnderTest[0];
+        // await sut.Invoking(x => x.JoinConsumerGroupAsync(_joinConsumerGroupRequest))
+        //     .Should()
+        //     .NotThrowAsync();
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(5)]
-    public async Task GetConsumerGroupById_Should_Return_ValidMembersCount()
-    {
-        var sut = _fixture.SubjectsUnderTest[0];
-        var response = await sut.GetConsumerGroupByIdAsync(
-            Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.StreamRequest.StreamId!), Identifier.Numeric((int)ConsumerGroupFixtureBootstrap.TopicRequest.TopicId!),
-            ConsumerGroupId);
-        response!.MembersCount.Should().Be(1);
-    }
-
-    [Fact(Skip = SkipMessage), TestPriority(6)]
+    [Fact, TestPriority(5)]
     public async Task LeaveConsumerGroup_Should_LeaveConsumerGroup_Successfully()
     {
-        var sut = _fixture.SubjectsUnderTest[0];
-        await sut.Invoking(x => x.LeaveConsumerGroupAsync(_leaveConsumerGroupRequest))
+        // act & assert
+        await _fixture.HttpSut.Invoking(x => x.LeaveConsumerGroupAsync(_leaveConsumerGroupRequest))
             .Should()
-            .NotThrowAsync();
+            .ThrowAsync<FeatureUnavailableException>();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var sut = _fixture.SubjectsUnderTest[0];
+        // await sut.Invoking(x => x.LeaveConsumerGroupAsync(_leaveConsumerGroupRequest))
+        //     .Should()
+        //     .ThrowAsync<FeatureUnavailableException>();
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(7)]
+    [Fact, TestPriority(6)]
     public async Task DeleteConsumerGroup_Should_DeleteConsumerGroup_Successfully()
     {
         var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
@@ -113,24 +163,37 @@ public sealed class ConsumerGroupE2E : IClassFixture<IggyConsumerGroupFixture>
         await Task.WhenAll(tasks);
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(8)]
+    [Fact, TestPriority(7)]
     public async Task JoinConsumerGroup_Should_Throw_InvalidResponse()
     {
-        var sut = _fixture.SubjectsUnderTest[0];
-        await sut.Invoking(x => x.JoinConsumerGroupAsync(_joinConsumerGroupRequest))
+        // act & assert
+        await _fixture.HttpSut.Invoking(x => x.LeaveConsumerGroupAsync(_leaveConsumerGroupRequest))
             .Should()
-            .ThrowExactlyAsync<InvalidResponseException>();
+            .ThrowAsync<FeatureUnavailableException>();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var sut = _fixture.SubjectsUnderTest[0];
+        // await sut.Invoking(x => x.JoinConsumerGroupAsync(_joinConsumerGroupRequest))
+        //     .Should()
+        //     .ThrowExactlyAsync<FeatureUnavailableException>();
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(9)]
+    [Fact, TestPriority(8)]
     public async Task DeleteConsumerGroup_Should_Throw_InvalidResponse()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            await sut.Invoking(x => x.DeleteConsumerGroupAsync(_deleteConsumerGroupRequest))
-                .Should()
-                .ThrowExactlyAsync<InvalidResponseException>();
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act & assert
+        await _fixture.HttpSut.Invoking(x => x.DeleteConsumerGroupAsync(_deleteConsumerGroupRequest))
+            .Should()
+            .ThrowExactlyAsync<InvalidResponseException>();
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     await sut.Invoking(x => x.DeleteConsumerGroupAsync(_deleteConsumerGroupRequest))
+        //         .Should()
+        //         .ThrowExactlyAsync<InvalidResponseException>();
+        // })).ToArray();
+        //
+        // await Task.WhenAll(tasks);
     }
 }

--- a/Iggy_SDK_Tests/E2ETests/UtilsE2E.cs
+++ b/Iggy_SDK_Tests/E2ETests/UtilsE2E.cs
@@ -17,18 +17,30 @@ public sealed class UtilsE2E : IClassFixture<IggyGeneralFixture>
         _fixture = fixture;
     }
 
-    [Fact(Skip = SkipMessage), TestPriority(1)]
+    [Fact, TestPriority(1)]
     public async Task GetStats_Should_ReturnValidResponse()
     {
-        var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
-        {
-            var response = await sut.GetStatsAsync();
-            response.Should().NotBeNull();
-            response!.MessagesCount.Should().Be(0);
-            response.PartitionsCount.Should().Be(0);
-            response.StreamsCount.Should().Be(0);
-            response.TopicsCount.Should().Be(0);
-        })).ToArray();
-        await Task.WhenAll(tasks);
+        // act
+        var response = await _fixture.HttpSut.GetStatsAsync();
+        
+        // assert
+        response.Should().NotBeNull();
+        response!.MessagesCount.Should().Be(0);
+        response.PartitionsCount.Should().Be(0);
+        response.StreamsCount.Should().Be(0);
+        response.TopicsCount.Should().Be(0);
+        
+        // TODO: This code block is commented because TCP implementation is not working properly.
+        // var tasks = _fixture.SubjectsUnderTest.Select(sut => Task.Run(async () =>
+        // {
+        //     var response = await sut.GetStatsAsync();
+        //     response.Should().NotBeNull();
+        //     response!.MessagesCount.Should().Be(0);
+        //     response.PartitionsCount.Should().Be(0);
+        //     response.StreamsCount.Should().Be(0);
+        //     response.TopicsCount.Should().Be(0);
+        // })).ToArray();
+        //
+        // await Task.WhenAll(tasks);
     }
 }


### PR DESCRIPTION
In this PR were fixed tests related to HTTP ConsumerGroup and Utils.

⚠️ The test `GetConsumerGroupById_Should_Return_ValidMembersCount()` was removed because the assert condition doesn't make sense since the test `GetConsumerGroupById_Should_Return_ValidResponse()`already had tested the members are (0) zero, and it's never returned the total of members.